### PR TITLE
Fixed import error with Typescript

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,8 +41,14 @@
   "module": "./dist/smooth-dnd-react.mjs",
   "exports": {
     ".": {
-      "import": "./dist/smooth-dnd-react.mjs",
-      "require": "./dist/smooth-dnd-react.umd.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/smooth-dnd-react.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/smooth-dnd-react.umd.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
The Typescript error was:

```
Could not find a declaration file for module '@smooth-dnd/react'. '/home/yewo/code/resume-builder/node_modules/@smooth-dnd/react/dist/smooth-dnd-react.mjs' implicitly has an 'any' type.
  There are types at '/home/yewo/code/resume-builder/node_modules/@smooth-dnd/react/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@smooth-dnd/react' library may need to update its package.json or typings.ts(7016)
```

I'm using:
 - Typescript 5.0.2
 - Node 18.15.0
 - React 18.2.0